### PR TITLE
Add support for 11xx effect on noise channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,12 +78,18 @@ To apply a Panning Macro to a different channel, use the ``--pan <channel_number
 - 0Bxx - Position Jump
 - 0Dxx - Pattern Break
 - 0Fxx - Set Speed
+- 11xx - Set Noise Length 
 - 12xx - Set Duty Cycle
 - 80xx - Set Pan (Software)
 - ECxx - Note Cut
 - EDxx - Note Delay
 
 **FFxx (Stop song) is not supported.** If you want the song to stop, create another row and loop it forever with 0Bxx.
+
+### Noise Length (11xx)
+Only affects the Noise channel. 1099 = 15-bit LFSR, 1101 = 7-bit LSFR / tone-like noise)
+
+Furnace effect 11xx (noise mode) is converted as an instrument-level setting in hUGETracker. Because hUGETracker stores this as part of the noise instrument rather than a pattern effect, all notes using the same noise instrument should use the same 11xx value for consistent conversion results.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ To apply a Panning Macro to a different channel, use the ``--pan <channel_number
 **FFxx (Stop song) is not supported.** If you want the song to stop, create another row and loop it forever with 0Bxx.
 
 ### Noise Length (11xx)
-Only affects the Noise channel. 1099 = 15-bit LFSR, 1101 = 7-bit LSFR / tone-like noise)
+Only affects the Noise channel. 1099 = 15-bit LFSR, 1101 = 7-bit LSFR / tone-like noise
 
 Furnace effect 11xx (noise mode) is converted as an instrument-level setting in hUGETracker. Because hUGETracker stores this as part of the noise instrument rather than a pattern effect, all notes using the same noise instrument should use the same 11xx value for consistent conversion results.
 

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -311,8 +311,11 @@ namespace fur2Uge
             List<FurInstrument> furPulseInstruments = new List<FurInstrument>();
             List<FurInstrument> furWaveInstruments = new List<FurInstrument>();
             List<FurInstrument> furNoiseInstruments = new List<FurInstrument>();
-            Dictionary<int, List<int>> seenVolumes = new Dictionary<int, List<int>>();
-            Dictionary<(int, byte), int> clonedVolInstrumentLookup = new Dictionary<(int, byte), int>();  // Instrument Lookup: [ InstrumentID, Volume Level ] = remapped GB Instrument
+            Dictionary<int, List<int>> seenVolumes = new Dictionary<int, List<int>>(); // Instrument Lookup: [ InstrumentID, Volume Level ] = remapped GB Instrument
+            Dictionary<(int, byte), int> clonedVolInstrumentLookup = new Dictionary<(int, byte), int>();
+            Dictionary<int, uint> noiseInstrumentModes = new Dictionary<int, uint>();
+            int[] currentUgeInstrument = new int[] { -1, -1, -1, -1 };  // Instrument Lookup: [ InstrumentID, Volume Level ] = remapped GB Instrument
+
             for (var i = 0; i < moduleInfo.GlobalInstruments.Count; i++)
             {
                 seenVolumes[i] = new List<int>();
@@ -549,6 +552,7 @@ namespace fur2Uge
                             }
 
                             patCon.SetInstrument((GBChannel)chanID, (byte)ugePatternID, rowIndex, instrVal);
+                            currentUgeInstrument[chanID] = instrVal;
                         }
 
                         // Now copy the volume column (which might or might not get overwritten if an effect is present)
@@ -675,6 +679,13 @@ namespace fur2Uge
                             switch ((UgeEffectTable)furFxCmd)
                             {
                                 default:
+                                    break;
+                                case (UgeEffectTable)0x11:
+                                    if (chanID == 3 && currentUgeInstrument[chanID] >= 0)
+                                    {
+                                        noiseInstrumentModes[currentUgeInstrument[chanID]] = (furFxVal == 0x01) ? 1U : 0U;
+                                        ugeFxCmd = UgeEffectTable.EMPTY;
+                                    }
                                     break;
                                 case (UgeEffectTable)0xEC: // Note cut
                                     ugeFxCmd = UgeEffectTable.NOTE_CUT;
@@ -822,6 +833,11 @@ namespace fur2Uge
                 List<FurInstrMacro> macros = noiseInst.GetMacros();
 
                 UgeInstrument ugeNoise = new UgeInstrument(name, (uint)UgeInstrumentType.NOISE, gbParams.Item1, (gbParams.Item2 > 0x1) ? 0U : 1U, gbParams.Item3, gbParams.Item4, gbParams.Item5, gbParams.Item6, gbParams.Item7, macros, null);
+
+                if (noiseInstrumentModes.TryGetValue(instrIndex, out uint noiseMode))
+                {
+                    ugeNoise.SetNoiseMode(noiseMode);
+                }
 
                 ugeFile.SetNoiseInstr(instrIndex, ugeNoise);
                 instrIndex++;

--- a/src/Uge/UgeInstrument.cs
+++ b/src/Uge/UgeInstrument.cs
@@ -396,6 +396,12 @@
             {
                 _dutyCycle = value;
             }
+
+            public void SetNoiseMode(uint value)
+            {
+                _noiseMode = value;
+            }
         }
     }
 }
+


### PR DESCRIPTION
A little feature that simplified my current workflow. If you set effect `1101` for all notes for an instrument in the noise channel, it will automatically set the "7 bit counter (more tone-like output" checkbox for that noise instrument in hUGETracker.

<img width="130" height="576" alt="image" src="https://github.com/user-attachments/assets/b4d58b48-0e74-4152-8cd8-ca1bc464577c" />

<img width="760" height="675" alt="image" src="https://github.com/user-attachments/assets/3e73de20-338d-4496-b3fb-040a203f3ff0" />

